### PR TITLE
Add kitspace.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # d20-hardware
-Hardware design files for the icosahedran d20 build.
+Hardware design files for the icosahedron d20 build.
 
 Read the blog post to read more about the project: https://gregdavill.com/blog/d20
 

--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,37 @@
+multi:
+  d20-control:
+    summary: 2,400 LED Icosahedron (d20) - Controller Board
+    readme: README.md
+    bom: pcb/controller/d20_r0.1/kicad-src/d20_r0.1.kicad_pcb
+    eda:
+      type: kicad
+      pcb: pcb/controller/d20_r0.1/kicad-src/d20_r0.1.kicad_pcb
+    color: red
+    site: https://gregdavill.com/blog/d20
+  d20-control-panel-2x1:
+    summary: 2,400 LED Icosahedron (d20) - Controller Board 2x1 Panel
+    readme: README.md
+    bom: pcb/controller/d20_r0.1/panel-2x1/d20_r0.1_panel.kicad_pcb
+    eda:
+      type: kicad
+      pcb: pcb/controller/d20_r0.1/panel-2x1/d20_r0.1_panel.kicad_pcb
+    color: red
+    site: https://gregdavill.com/blog/d20
+  d20-tri:
+    summary: 2,400 LED Icosahedron (d20) - LED Board (r0.3)
+    readme: README.md
+    bom: pcb/led-panels/d20_tri_r0.3/kicad-src/d20_tri_r0.3.kicad_pcb
+    eda:
+      type: kicad
+      pcb: pcb/led-panels/d20_tri_r0.3/kicad-src/d20_tri_r0.3.kicad_pcb
+    color: black
+    site: https://gregdavill.com/blog/d20
+  d20-tri-panel-4x1:
+    summary: 2,400 LED Icosahedron (d20) - LED Board 4x1 Panel (r0.3)
+    readme: README.md
+    bom: pcb/led-panels/d20_tri_r0.3/panel-4x1/d20_tri_r0.3_4x1.kicad_pcb
+    eda:
+      type: kicad
+      pcb: pcb/led-panels/d20_tri_r0.3/panel-4x1/d20_tri_r0.3_4x1.kicad_pcb
+    color: black
+    site: https://gregdavill.com/blog/d20


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/206854/123275611-610cad80-d4fc-11eb-8b45-e4eaf449ad18.png)

Since you [seemed enthusiastic about adding the OrangCrab](https://github.com/gregdavill/OrangeCrab/pull/14) but it was blocked on the manufacturing requirements. Looks like this project is within capabilities of JLC and PCBway etc. so I thought it might be a nice project to actually put up Kitspace pages for. 

[Here is a preview](http://add-d20.preview.kitspace.org/).

BOMs are generated from the .kicad_pcb files so could be improved. Kitspace [Bom Builder](https://github.com/kitspace/bom-builder/) ([more info](https://kitspace.org/bom-builder/)) could help with that, let me know if you'de like free access to a hosted version to try it out. 